### PR TITLE
make ListPeer use the stream context

### DIFF
--- a/pkg/server/grpc_server.go
+++ b/pkg/server/grpc_server.go
@@ -119,7 +119,7 @@ func (a *BfdApiServer) DeletePeer(ctx context.Context, req *api.DeletePeerReques
 }
 
 func (a *BfdApiServer) ListPeer(req *api.ListPeerRequest, stream api.BfdApi_ListPeerServer) error {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(stream.Context())
 	defer cancel()
 	var err error
 


### PR DESCRIPTION
Rather than creating its own context, use the one available from the
stream. This follows the example from MonitorPeer.

fixes: #7